### PR TITLE
Fix empty query argument

### DIFF
--- a/rolabesti/mongo.py
+++ b/rolabesti/mongo.py
@@ -63,7 +63,7 @@ def search(arguments):
     tracks = []
     length = 0
     length_filters = {}
-    filters = []
+    filters = [{}]
     logger = getLogger(__name__)
 
     with get_collection() as collection:


### PR DESCRIPTION
Fixes empty filters for the and operator.

Error: `pymongo.errors.OperationFailure: $and/$or/$nor must be a nonempty array`.