### PR TITLE
Set proper mutagen errors

### DIFF
--- a/rolabesti/controllers/parser.py
+++ b/rolabesti/controllers/parser.py
@@ -1,6 +1,7 @@
 import re
 from pathlib import Path
 
+from mutagen import MutagenError
 from mutagen.mp3 import MP3
 from pydantic import ValidationError
 
@@ -84,7 +85,7 @@ class Parser:
         """
         try:
             return int(MP3(trackpath).info.length)
-        except:
+        except MutagenError:
             return
 
     @staticmethod

--- a/rolabesti/controllers/utils.py
+++ b/rolabesti/controllers/utils.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
+from mutagen import MutagenError
 from mutagen.easyid3 import EasyID3
-from mutagen.id3._util import ID3NoHeaderError
 
 
 def add_prefix_to_dict(d: dict, prefix: str) -> dict:
@@ -16,5 +16,5 @@ def get_id3_dict(trackpath: Path) -> EasyID3 | None:
     """
     try:
         return EasyID3(trackpath)
-    except ID3NoHeaderError:
+    except MutagenError:
         return


### PR DESCRIPTION
`mutagen` related errors are delimited with the base `MutagenError`.