### PR TITLE
Set absolute imports in cli

### DIFF
--- a/rolabesti/cli/commands/config.py
+++ b/rolabesti/cli/commands/config.py
@@ -3,7 +3,7 @@ from typing import Annotated
 
 import typer
 
-from ..utils import validate_length_limits
+from rolabesti.cli.utils import validate_length_limits
 from rolabesti.config import get_settings, max_overlap_length
 from rolabesti.controllers import ConfigController
 from rolabesti.models import Sortings

--- a/rolabesti/cli/commands/copy.py
+++ b/rolabesti/cli/commands/copy.py
@@ -3,7 +3,7 @@ from typing import Annotated
 
 import typer
 
-from ..options import (
+from rolabesti.cli.options import (
     artist_option,
     title_option,
     album_option,
@@ -14,7 +14,7 @@ from ..options import (
     max_tracklist_length_option,
     sorting_option,
 )
-from ..utils import validate_length_limits
+from rolabesti.cli.utils import validate_length_limits
 from rolabesti.config import get_settings
 from rolabesti.controllers import CopyController
 

--- a/rolabesti/cli/commands/list.py
+++ b/rolabesti/cli/commands/list.py
@@ -1,6 +1,6 @@
 import typer
 
-from ..options import (
+from rolabesti.cli.options import (
     artist_option,
     title_option,
     album_option,
@@ -10,7 +10,7 @@ from ..options import (
     min_track_length_option,
     sorting_option,
 )
-from ..utils import validate_length_limits
+from rolabesti.cli.utils import validate_length_limits
 from rolabesti.config import get_settings
 from rolabesti.controllers import ListController
 

--- a/rolabesti/cli/commands/play.py
+++ b/rolabesti/cli/commands/play.py
@@ -2,7 +2,7 @@ from typing import Annotated
 
 import typer
 
-from ..options import (
+from rolabesti.cli.options import (
     artist_option,
     title_option,
     album_option,
@@ -13,7 +13,7 @@ from ..options import (
     max_tracklist_length_option,
     sorting_option,
 )
-from ..utils import validate_length_limits
+from rolabesti.cli.utils import validate_length_limits
 from rolabesti.config import get_settings, max_overlap_length
 from rolabesti.controllers import PlayController
 

--- a/rolabesti/cli/commands/tag.py
+++ b/rolabesti/cli/commands/tag.py
@@ -2,7 +2,7 @@ from typing import Annotated
 
 import typer
 
-from ..options import (
+from rolabesti.cli.options import (
     artist_option,
     title_option,
     album_option,
@@ -12,7 +12,7 @@ from ..options import (
     min_track_length_option,
     enum_callback,
 )
-from ..utils import validate_length_limits
+from rolabesti.cli.utils import validate_length_limits
 from rolabesti.config import get_settings
 from rolabesti.controllers import TagController
 from rolabesti.models import ID3Tags

--- a/rolabesti/cli/main.py
+++ b/rolabesti/cli/main.py
@@ -4,8 +4,8 @@ import typer
 from click import Context
 from typer.core import TyperGroup
 
-from .commands import config, copy, init, list_, play, tag
 from rolabesti import __app_name__, __description__, __version__
+from rolabesti.cli.commands import config, copy, init, list_, play, tag
 
 
 class OrderCommandsTyperGroup(TyperGroup):


### PR DESCRIPTION
Absolute imports are set in `cli` to allow automatic docs generation.